### PR TITLE
Stats voor alle pages + graph + small fixes.

### DIFF
--- a/BackendAPI/API/Controllers/KoperController.cs
+++ b/BackendAPI/API/Controllers/KoperController.cs
@@ -61,6 +61,24 @@ public class KoperController : ControllerBase
         return HttpSuccess<AccountOutputDto>.Ok(result, "Koper account updated successfully");
     }
 
+    [HttpGet("stats")]
+    public async Task<IActionResult> GetKoperStats()
+    {
+        var (koperId, _) = GetUserClaim.GetInfo(User);
+        var query = new GetKoperStatsCommand(koperId);
+        var result = await _mediator.Send(query);
+        return HttpSuccess<KoperStatsOutputDto>.Ok(result);
+    }
+
+    [HttpGet("veiling-stats")]
+    public async Task<IActionResult> GetKoperVeilingStats()
+    {
+        var (koperId, _) = GetUserClaim.GetInfo(User);
+        var query = new GetKoperVeilingStatsCommand(koperId);
+        var result = await _mediator.Send(query);
+        return HttpSuccess<KoperVeilingStatsOutputDto>.Ok(result);
+    }
+
     [HttpPost("address")]
     public async Task<IActionResult> CreateAddress([FromBody] AddressInputDto address)
     {

--- a/BackendAPI/API/Controllers/KwekerController.cs
+++ b/BackendAPI/API/Controllers/KwekerController.cs
@@ -204,4 +204,31 @@ public class KwekerController : ControllerBase
         var result = await _mediator.Send(command);
         return HttpSuccess<VeilingKlokOutputDto>.Ok(result);
     }
+
+    [HttpGet("stats")]
+    public async Task<IActionResult> GetKwekerStats()
+    {
+        var (kwekerId, _) = GetUserClaim.GetInfo(User);
+        var command = new GetKwekerStatsCommand(kwekerId);
+        var result = await _mediator.Send(command);
+        return HttpSuccess<KwekerStatsOutputDto>.Ok(result);
+    }
+
+    [HttpGet("product-stats")]
+    public async Task<IActionResult> GetKwekerProductStats()
+    {
+        var (kwekerId, _) = GetUserClaim.GetInfo(User);
+        var command = new GetKwekerProductStatsCommand(kwekerId);
+        var result = await _mediator.Send(command);
+        return HttpSuccess<KwekerProductStatsOutputDto>.Ok(result);
+    }
+
+    [HttpGet("order-stats")]
+    public async Task<IActionResult> GetKwekerOrderStats()
+    {
+        var (kwekerId, _) = GetUserClaim.GetInfo(User);
+        var command = new GetKwekerOrderStatsCommand(kwekerId);
+        var result = await _mediator.Send(command);
+        return HttpSuccess<KwekerOrderStatsOutputDto>.Ok(result);
+    }
 }

--- a/BackendAPI/API/Controllers/MeesterController.cs
+++ b/BackendAPI/API/Controllers/MeesterController.cs
@@ -66,6 +66,15 @@ public class MeesterController : ControllerBase
         return HttpSuccess<AccountOutputDto>.Ok(result, "Meester account updated successfully");
     }
 
+    [HttpGet("stats")]
+    public async Task<IActionResult> GetMeesterStats()
+    {
+        var (meesterId, _) = GetUserClaim.GetInfo(User);
+        var query = new GetMeesterStatsCommand(meesterId);
+        var result = await _mediator.Send(query);
+        return HttpSuccess<MeesterStatsOutputDto>.Ok(result);
+    }
+
     [HttpPost("order/{orderId}/product/{productItemId}")]
     public async Task<IActionResult> UpdateOrderProduct(
         Guid orderId,

--- a/BackendAPI/Application/DTOs/Output/KoperStatsOutputDto.cs
+++ b/BackendAPI/Application/DTOs/Output/KoperStatsOutputDto.cs
@@ -1,0 +1,9 @@
+namespace Application.DTOs.Output;
+
+public class KoperStatsOutputDto
+{
+    public required int TotalOrders { get; set; }
+    public required int PendingOrders { get; set; }
+    public required int CompletedOrders { get; set; }
+    public required int CanceledOrders { get; set; }
+}

--- a/BackendAPI/Application/DTOs/Output/KoperVeilingStatsOutputDto.cs
+++ b/BackendAPI/Application/DTOs/Output/KoperVeilingStatsOutputDto.cs
@@ -1,0 +1,9 @@
+namespace Application.DTOs.Output;
+
+public class KoperVeilingStatsOutputDto
+{
+    public required int ActiveAuctions { get; set; }
+    public required int ScheduledAuctions { get; set; }
+    public required int AvailableProducts { get; set; }
+    public required int YourPurchases { get; set; }
+}

--- a/BackendAPI/Application/DTOs/Output/KwekerOrderStatsOutputDto.cs
+++ b/BackendAPI/Application/DTOs/Output/KwekerOrderStatsOutputDto.cs
@@ -1,0 +1,9 @@
+namespace Application.DTOs.Output;
+
+public class KwekerOrderStatsOutputDto
+{
+    public int TotalOrders { get; set; }
+    public int PendingOrders { get; set; }
+    public int CompletedOrders { get; set; }
+    public int CanceledOrders { get; set; }
+}

--- a/BackendAPI/Application/DTOs/Output/KwekerProductStatsOutputDto.cs
+++ b/BackendAPI/Application/DTOs/Output/KwekerProductStatsOutputDto.cs
@@ -1,0 +1,8 @@
+namespace Application.DTOs.Output;
+
+public class KwekerProductStatsOutputDto
+{
+    public int TotalProducts { get; set; }
+    public int InventoryStock { get; set; }
+    public int ActiveAuctions { get; set; }
+}

--- a/BackendAPI/Application/DTOs/Output/KwekerStatsOutputDto.cs
+++ b/BackendAPI/Application/DTOs/Output/KwekerStatsOutputDto.cs
@@ -7,6 +7,7 @@ public class KwekerStatsOutputDto
     public required decimal TotalRevenue { get; set; }
     public required int OrdersReceived { get; set; }
     public required List<MonthlyRevenueDto> MonthlyRevenue { get; set; }
+    public required List<DailyRevenueDto> DailyRevenue { get; set; }
 }
 
 public class MonthlyRevenueDto
@@ -14,5 +15,14 @@ public class MonthlyRevenueDto
     public required int Year { get; set; }
     public required int Month { get; set; }
     public required string MonthName { get; set; }
+    public required decimal Revenue { get; set; }
+}
+
+public class DailyRevenueDto
+{
+    public required int Year { get; set; }
+    public required int Month { get; set; }
+    public required int Day { get; set; }
+    public required string DateLabel { get; set; }
     public required decimal Revenue { get; set; }
 }

--- a/BackendAPI/Application/DTOs/Output/KwekerStatsOutputDto.cs
+++ b/BackendAPI/Application/DTOs/Output/KwekerStatsOutputDto.cs
@@ -5,5 +5,14 @@ public class KwekerStatsOutputDto
     public required int TotalProducts { get; set; }
     public required int ActiveAuctions { get; set; }
     public required decimal TotalRevenue { get; set; }
-    public required int StemsSold { get; set; }
+    public required int OrdersReceived { get; set; }
+    public required List<MonthlyRevenueDto> MonthlyRevenue { get; set; }
+}
+
+public class MonthlyRevenueDto
+{
+    public required int Year { get; set; }
+    public required int Month { get; set; }
+    public required string MonthName { get; set; }
+    public required decimal Revenue { get; set; }
 }

--- a/BackendAPI/Application/DTOs/Output/MeesterStatsOutputDto.cs
+++ b/BackendAPI/Application/DTOs/Output/MeesterStatsOutputDto.cs
@@ -1,0 +1,9 @@
+namespace Application.DTOs.Output;
+
+public class MeesterStatsOutputDto
+{
+    public required int TotalVeilingKlokken { get; set; }
+    public required int ActiveVeilingKlokken { get; set; }
+    public required int TotalProducts { get; set; }
+    public required int TotalOrders { get; set; }
+}

--- a/BackendAPI/Application/UseCases/Order/GetKoperStatsHandler.cs
+++ b/BackendAPI/Application/UseCases/Order/GetKoperStatsHandler.cs
@@ -1,0 +1,48 @@
+using Application.DTOs.Output;
+using Application.Repositories;
+using Domain.Enums;
+using MediatR;
+
+namespace Application.UseCases.Order;
+
+public record GetKoperStatsCommand(Guid KoperId) : IRequest<KoperStatsOutputDto>;
+
+public class GetKoperStatsHandler : IRequestHandler<GetKoperStatsCommand, KoperStatsOutputDto>
+{
+    private readonly IOrderRepository _orderRepository;
+
+    public GetKoperStatsHandler(IOrderRepository orderRepository)
+    {
+        _orderRepository = orderRepository;
+    }
+
+    public async Task<KoperStatsOutputDto> Handle(GetKoperStatsCommand request, CancellationToken cancellationToken)
+    {
+        // Get all orders for this koper
+        var (allOrders, totalCount) = await _orderRepository.GetAllWithFilterAsync(
+            statusFilter: null,
+            beforeDate: null,
+            afterDate: null,
+            productId: null,
+            koperId: request.KoperId,
+            klokId: null,
+            pageNumber: 1,
+            pageSize: int.MaxValue
+        );
+
+        var ordersList = allOrders.ToList();
+
+        // Count orders by status
+        var pendingOrders = ordersList.Count(o => o.Status == OrderStatus.Open || o.Status == OrderStatus.Processing);
+        var completedOrders = ordersList.Count(o => o.Status == OrderStatus.Delivered || o.Status == OrderStatus.Processed);
+        var canceledOrders = ordersList.Count(o => o.Status == OrderStatus.Cancelled);
+
+        return new KoperStatsOutputDto
+        {
+            TotalOrders = totalCount,
+            PendingOrders = pendingOrders,
+            CompletedOrders = completedOrders,
+            CanceledOrders = canceledOrders
+        };
+    }
+}

--- a/BackendAPI/Application/UseCases/Order/GetKwekerOrderStatsHandler.cs
+++ b/BackendAPI/Application/UseCases/Order/GetKwekerOrderStatsHandler.cs
@@ -28,9 +28,7 @@ public class GetKwekerOrderStatsHandler : IRequestHandler<GetKwekerOrderStatsCom
         // Count orders by status
         var pendingOrders = allOrders.Count(o => o.Order.Status == OrderStatus.Open || o.Order.Status == OrderStatus.Processing);
         var completedOrders = allOrders.Count(o => o.Order.Status == OrderStatus.Delivered || o.Order.Status == OrderStatus.Processed);
-        
-        // Canceled orders - keep at 0 for now as requested
-        var canceledOrders = 0;
+        var canceledOrders = allOrders.Count(o => o.Order.Status == OrderStatus.Cancelled);
 
         return new KwekerOrderStatsOutputDto
         {

--- a/BackendAPI/Application/UseCases/Order/GetKwekerOrderStatsHandler.cs
+++ b/BackendAPI/Application/UseCases/Order/GetKwekerOrderStatsHandler.cs
@@ -1,0 +1,43 @@
+using Application.DTOs.Output;
+using Application.Repositories;
+using Domain.Enums;
+using MediatR;
+
+namespace Application.UseCases.Order;
+
+public record GetKwekerOrderStatsCommand(Guid KwekerId) : IRequest<KwekerOrderStatsOutputDto>;
+
+public class GetKwekerOrderStatsHandler : IRequestHandler<GetKwekerOrderStatsCommand, KwekerOrderStatsOutputDto>
+{
+    private readonly IOrderRepository _orderRepository;
+    private readonly IProductRepository _productRepository;
+
+    public GetKwekerOrderStatsHandler(IOrderRepository orderRepository, IProductRepository productRepository)
+    {
+        _orderRepository = orderRepository;
+        _productRepository = productRepository;
+    }
+
+    public async Task<KwekerOrderStatsOutputDto> Handle(GetKwekerOrderStatsCommand request, CancellationToken cancellationToken)
+    {
+        // Get all orders for this kweker's products
+        var (allOrders, totalCount) = await _orderRepository.GetAllKwekerWithFilterAsync(
+            null, null, null, null, null, null, request.KwekerId, 1, int.MaxValue
+        );
+
+        // Count orders by status
+        var pendingOrders = allOrders.Count(o => o.Order.Status == OrderStatus.Open || o.Order.Status == OrderStatus.Processing);
+        var completedOrders = allOrders.Count(o => o.Order.Status == OrderStatus.Delivered || o.Order.Status == OrderStatus.Processed);
+        
+        // Canceled orders - keep at 0 for now as requested
+        var canceledOrders = 0;
+
+        return new KwekerOrderStatsOutputDto
+        {
+            TotalOrders = totalCount,
+            PendingOrders = pendingOrders,
+            CompletedOrders = completedOrders,
+            CanceledOrders = canceledOrders
+        };
+    }
+}

--- a/BackendAPI/Application/UseCases/Order/UpdateOrderStatusHandler.cs
+++ b/BackendAPI/Application/UseCases/Order/UpdateOrderStatusHandler.cs
@@ -45,8 +45,8 @@ public sealed class UpdateOrderStatusHandler
             var klok = await _veilingKlokRepository.GetByIdAsync(order.VeilingKlokId)
                        ?? throw RepositoryException.NotFoundOrder();
 
-            // If Klok is still under auction is not possible to change status active
-            if (klok.Status < VeilingKlokStatus.Ended)
+            // Only allow status change if Klok is not actively running (Started or Paused)
+            if (klok.Status == VeilingKlokStatus.Started || klok.Status == VeilingKlokStatus.Paused)
                 throw CustomException.InvalidOperationKlokStillRunning();
 
             // Business rules for status transition can be added here

--- a/BackendAPI/Application/UseCases/Product/GetKwekerProductStatsHandler.cs
+++ b/BackendAPI/Application/UseCases/Product/GetKwekerProductStatsHandler.cs
@@ -1,0 +1,45 @@
+using Application.DTOs.Output;
+using Application.Repositories;
+using Domain.Enums;
+using MediatR;
+
+namespace Application.UseCases.Product;
+
+public record GetKwekerProductStatsCommand(Guid KwekerId) : IRequest<KwekerProductStatsOutputDto>;
+
+public class GetKwekerProductStatsHandler : IRequestHandler<GetKwekerProductStatsCommand, KwekerProductStatsOutputDto>
+{
+    private readonly IProductRepository _productRepository;
+    private readonly IVeilingKlokRepository _veilingKlokRepository;
+
+    public GetKwekerProductStatsHandler(IProductRepository productRepository, IVeilingKlokRepository veilingKlokRepository)
+    {
+        _productRepository = productRepository;
+        _veilingKlokRepository = veilingKlokRepository;
+    }
+
+    public async Task<KwekerProductStatsOutputDto> Handle(GetKwekerProductStatsCommand request, CancellationToken cancellationToken)
+    {
+        // Get all products for this kweker
+        var (productList, totalCount) = await _productRepository.GetAllWithFilterAsync(
+            null, null, null, request.KwekerId, null, 1, int.MaxValue
+        );
+
+        // Calculate inventory stock (sum of all product quantities)
+        var inventoryStock = productList.Sum(p => p.Product.Stock);
+
+        // Get active auctions - veilingkloks that are started
+        var activeKloks = await _veilingKlokRepository.GetAllByStatusAsync(VeilingKlokStatus.Started, cancellationToken);
+        
+        // For now, count all started kloks as potential active auctions for any kweker
+        // (A more accurate count would require checking VeilingKlokProduct relationship)
+        var activeAuctions = activeKloks.Count();
+
+        return new KwekerProductStatsOutputDto
+        {
+            TotalProducts = totalCount,
+            InventoryStock = inventoryStock,
+            ActiveAuctions = activeAuctions
+        };
+    }
+}

--- a/BackendAPI/Application/UseCases/Product/GetKwekerStatsHandler.cs
+++ b/BackendAPI/Application/UseCases/Product/GetKwekerStatsHandler.cs
@@ -1,0 +1,113 @@
+using Application.DTOs.Output;
+using Application.Repositories;
+using Domain.Enums;
+using MediatR;
+
+namespace Application.UseCases.Product;
+
+public sealed record GetKwekerStatsCommand(Guid KwekerId) : IRequest<KwekerStatsOutputDto>;
+
+public sealed class GetKwekerStatsHandler : IRequestHandler<GetKwekerStatsCommand, KwekerStatsOutputDto>
+{
+    private readonly IProductRepository _productRepository;
+    private readonly IOrderRepository _orderRepository;
+
+    public GetKwekerStatsHandler(IProductRepository productRepository, IOrderRepository orderRepository)
+    {
+        _productRepository = productRepository;
+        _orderRepository = orderRepository;
+    }
+
+    public async Task<KwekerStatsOutputDto> Handle(
+        GetKwekerStatsCommand request,
+        CancellationToken cancellationToken
+    )
+    {
+        // Get all products for this kweker
+        var (products, totalCount) = await _productRepository.GetAllWithFilterAsync(
+            nameFilter: null,
+            regionFilter: null,
+            maxPrice: null,
+            kwekerId: request.KwekerId,
+            klokId: null,
+            pageNumber: 1,
+            pageSize: int.MaxValue
+        );
+
+        var productList = products.ToList();
+        var totalProducts = totalCount;
+        var activeAuctions = productList.Count(p => p.Product.IsBeingAuctioned);
+
+        // Get all orders for this kweker's products
+        var productIds = productList.Select(p => p.Product.Id).ToList();
+        
+        var (orders, _) = await _orderRepository.GetAllKwekerWithFilterAsync(
+            ProductNameFilter: null,
+            KoperNameFilter: null,
+            statusFilter: null,
+            beforeDate: null,
+            afterDate: null,
+            productId: null,
+            kwekerId: request.KwekerId,
+            pageNumber: 1,
+            pageSize: int.MaxValue
+        );
+
+        var ordersList = orders.ToList();
+        
+        // Calculate total revenue from completed orders
+        var completedOrders = ordersList
+            .Where(o => o.Order.Status == OrderStatus.Processed || o.Order.Status == OrderStatus.Delivered)
+            .ToList();
+
+        decimal totalRevenue = 0;
+        int ordersReceived = completedOrders.Count;
+
+        foreach (var orderInfo in completedOrders)
+        {
+            var orderItems = orderInfo.Order.OrderItems
+                .Where(oi => productIds.Contains(oi.ProductId))
+                .ToList();
+
+            foreach (var item in orderItems)
+            {
+                totalRevenue += item.PriceAtPurchase * item.Quantity;
+            }
+        }
+
+        // Calculate monthly revenue for the last 12 months
+        var monthlyRevenue = new List<MonthlyRevenueDto>();
+        var today = DateTimeOffset.UtcNow;
+        
+        for (int i = 11; i >= 0; i--)
+        {
+            var targetDate = today.AddMonths(-i);
+            var monthStart = new DateTimeOffset(targetDate.Year, targetDate.Month, 1, 0, 0, 0, TimeSpan.Zero);
+            var monthEnd = monthStart.AddMonths(1);
+
+            var monthRevenue = ordersList
+                .Where(o => (o.Order.Status == OrderStatus.Processed || o.Order.Status == OrderStatus.Delivered)
+                    && o.Order.CreatedAt >= monthStart
+                    && o.Order.CreatedAt < monthEnd)
+                .SelectMany(o => o.Order.OrderItems.Where(oi => productIds.Contains(oi.ProductId)))
+                .Sum(item => item.PriceAtPurchase * item.Quantity);
+
+            monthlyRevenue.Add(new MonthlyRevenueDto
+            {
+                Year = targetDate.Year,
+                Month = targetDate.Month,
+                MonthName = targetDate.ToString("MMM yyyy"),
+                Revenue = monthRevenue
+            });
+        }
+
+        return new KwekerStatsOutputDto
+        {
+            TotalProducts = totalProducts,
+            ActiveAuctions = activeAuctions,
+            TotalRevenue = totalRevenue,
+            OrdersReceived = ordersReceived,
+            MonthlyRevenue = monthlyRevenue
+        };
+    }
+}

--- a/BackendAPI/Application/UseCases/VeilingKlok/GetKoperVeilingStatsHandler.cs
+++ b/BackendAPI/Application/UseCases/VeilingKlok/GetKoperVeilingStatsHandler.cs
@@ -1,0 +1,78 @@
+using Application.DTOs.Output;
+using Application.Repositories;
+using Domain.Enums;
+using MediatR;
+
+namespace Application.UseCases.VeilingKlok;
+
+public record GetKoperVeilingStatsCommand(Guid KoperId) : IRequest<KoperVeilingStatsOutputDto>;
+
+public class GetKoperVeilingStatsHandler : IRequestHandler<GetKoperVeilingStatsCommand, KoperVeilingStatsOutputDto>
+{
+    private readonly IVeilingKlokRepository _veilingKlokRepository;
+    private readonly IProductRepository _productRepository;
+    private readonly IOrderRepository _orderRepository;
+
+    public GetKoperVeilingStatsHandler(
+        IVeilingKlokRepository veilingKlokRepository,
+        IProductRepository productRepository,
+        IOrderRepository orderRepository
+    )
+    {
+        _veilingKlokRepository = veilingKlokRepository;
+        _productRepository = productRepository;
+        _orderRepository = orderRepository;
+    }
+
+    public async Task<KoperVeilingStatsOutputDto> Handle(
+        GetKoperVeilingStatsCommand request,
+        CancellationToken cancellationToken
+    )
+    {
+        // Get all active veilingklokken (Started or Paused)
+        var activeKlokken = await _veilingKlokRepository.GetAllByStatusAsync(VeilingKlokStatus.Started, cancellationToken);
+        var pausedKlokken = await _veilingKlokRepository.GetAllByStatusAsync(VeilingKlokStatus.Paused, cancellationToken);
+        var activeAuctions = activeKlokken.Count() + pausedKlokken.Count();
+
+        // Get scheduled veilingklokken
+        var scheduledKlokken = await _veilingKlokRepository.GetAllByStatusAsync(VeilingKlokStatus.Scheduled, cancellationToken);
+        var scheduledAuctions = scheduledKlokken.Count();
+
+        // Count available products in active auctions
+        int availableProducts = 0;
+        var allActiveKlokken = activeKlokken.Concat(pausedKlokken);
+        foreach (var klok in allActiveKlokken)
+        {
+            var (products, count) = await _productRepository.GetAllWithFilterAsync(
+                nameFilter: null,
+                regionFilter: null,
+                maxPrice: null,
+                kwekerId: null,
+                klokId: klok.Id,
+                pageNumber: 1,
+                pageSize: int.MaxValue
+            );
+            availableProducts += count;
+        }
+
+        // Get purchases for this koper
+        var (orders, totalOrders) = await _orderRepository.GetAllWithFilterAsync(
+            statusFilter: null,
+            beforeDate: null,
+            afterDate: null,
+            productId: null,
+            koperId: request.KoperId,
+            klokId: null,
+            pageNumber: 1,
+            pageSize: int.MaxValue
+        );
+
+        return new KoperVeilingStatsOutputDto
+        {
+            ActiveAuctions = activeAuctions,
+            ScheduledAuctions = scheduledAuctions,
+            AvailableProducts = availableProducts,
+            YourPurchases = totalOrders
+        };
+    }
+}

--- a/BackendAPI/Application/UseCases/VeilingKlok/GetMeesterStatsHandler.cs
+++ b/BackendAPI/Application/UseCases/VeilingKlok/GetMeesterStatsHandler.cs
@@ -1,0 +1,97 @@
+using Application.DTOs.Output;
+using Application.Repositories;
+using Domain.Enums;
+using MediatR;
+
+namespace Application.UseCases.VeilingKlok;
+
+public record GetMeesterStatsCommand(Guid MeesterId) : IRequest<MeesterStatsOutputDto>;
+
+public class GetMeesterStatsHandler : IRequestHandler<GetMeesterStatsCommand, MeesterStatsOutputDto>
+{
+    private readonly IVeilingKlokRepository _veilingKlokRepository;
+    private readonly IProductRepository _productRepository;
+    private readonly IOrderRepository _orderRepository;
+
+    public GetMeesterStatsHandler(
+        IVeilingKlokRepository veilingKlokRepository,
+        IProductRepository productRepository,
+        IOrderRepository orderRepository
+    )
+    {
+        _veilingKlokRepository = veilingKlokRepository;
+        _productRepository = productRepository;
+        _orderRepository = orderRepository;
+    }
+
+    public async Task<MeesterStatsOutputDto> Handle(
+        GetMeesterStatsCommand request,
+        CancellationToken cancellationToken
+    )
+    {
+        // Get all veilingklokken for this meester
+        var (klokken, totalKlokken) = await _veilingKlokRepository.GetAllWithFilterAndBidsAsync(
+            statusFilter: null,
+            region: null,
+            scheduledAfter: null,
+            scheduledBefore: null,
+            startedAfter: null,
+            startedBefore: null,
+            endedAfter: null,
+            endedBefore: null,
+            meesterId: request.MeesterId,
+            pageNumber: 1,
+            pageSize: int.MaxValue
+        );
+
+        var klokkenList = klokken.ToList();
+
+        // Count active veilingklokken (Started or Paused)
+        var activeKlokken = klokkenList.Count(k => 
+            k.VeilingKlok.Status == VeilingKlokStatus.Started || k.VeilingKlok.Status == VeilingKlokStatus.Paused
+        );
+
+        // Get all products across all veilingklokken
+        var klokIds = klokkenList.Select(k => k.VeilingKlok.Id).ToList();
+        int totalProducts = 0;
+        int totalOrders = 0;
+
+        foreach (var klokId in klokIds)
+        {
+            // Get products for this klok
+            var (products, productCount) = await _productRepository.GetAllWithFilterAsync(
+                nameFilter: null,
+                regionFilter: null,
+                maxPrice: null,
+                kwekerId: null,
+                klokId: klokId,
+                pageNumber: 1,
+                pageSize: int.MaxValue
+            );
+
+            totalProducts += productCount;
+
+            // Get orders for this klok
+            var (orders, orderCount) = await _orderRepository.GetAllWithFilterAsync(
+                statusFilter: null,
+                beforeDate: null,
+                afterDate: null,
+                productId: null,
+                koperId: null,
+                klokId: klokId,
+                pageNumber: 1,
+                pageSize: int.MaxValue
+            );
+
+            totalOrders += orderCount;
+        }
+
+        return new MeesterStatsOutputDto
+        {
+            TotalVeilingKlokken = totalKlokken,
+            ActiveVeilingKlokken = activeKlokken,
+            TotalProducts = totalProducts,
+            TotalOrders = totalOrders
+        };
+    }
+}

--- a/FrontendWeb/src/components/sections/koper/KoperStats.tsx
+++ b/FrontendWeb/src/components/sections/koper/KoperStats.tsx
@@ -1,0 +1,150 @@
+import React, {useEffect, useState} from 'react';
+import {useRootContext} from '../../contexts/RootContext';
+import {getKoperStats, getKoperVeilingStats} from '../../../controllers/server/koper';
+
+type StatsCardProps = {
+	title: string;
+	icon: React.ReactNode;
+	data: string;
+	percentage?: number;
+	enablePercentage?: boolean;
+}
+
+function StatsCard(props: StatsCardProps) {
+	const {t} = useRootContext();
+	const {title, icon, data, enablePercentage, percentage = 0.00} = props;
+	return (
+		<div className="kweker-stat-card">
+			<div className="kweker-stat-title">
+		        <span>
+			        {icon}
+ 				</span>
+				<p className="products-page-action-card-txt">
+					{title}
+				</p>
+			</div>
+			<div className="kweker-stat-data">
+				<p>
+					{data}
+				</p>
+			</div>
+
+			{
+				enablePercentage && (<div className="kweker-stat-row">
+				<span className="kweker-stat-label">
+					<p>
+						+{percentage}%
+					</p>
+				</span>
+					<span className="kweker-stat-row-txt"> {t('this_month')}</span>
+				</div>)
+			}
+		</div>
+	);
+}
+
+export function KoperStats() {
+	const {t} = useRootContext();
+	const [stats, setStats] = useState({
+		totalOrders: 0,
+		pendingOrders: 0,
+		completedOrders: 0,
+		canceledOrders: 0
+	});
+
+	useEffect(() => {
+		const fetchStats = async () => {
+			try {
+				const response = await getKoperStats();
+				if (response.data) {
+					setStats(response.data);
+				}
+			} catch (error) {
+				console.error('Failed to fetch koper stats:', error);
+			}
+		};
+
+		fetchStats();
+	}, []);
+
+	return (
+		<section className="kweker-stats meester-stats">
+			<StatsCard
+				title={t('total_orders')}
+				icon={<i className="bi bi-cart-fill"></i>}
+				data={stats.totalOrders.toString()}
+			/>
+
+			<StatsCard
+				title={t('pending_orders')}
+				icon={<i className="bi bi-clock-fill"></i>}
+				data={stats.pendingOrders.toString()}
+			/>
+
+			<StatsCard
+				title={t('completed_orders')}
+				icon={<i className="bi bi-check-circle-fill"></i>}
+				data={stats.completedOrders.toString()}
+			/>
+
+			<StatsCard
+				title={t('canceled_orders')}
+				icon={<i className="bi bi-x-circle-fill"></i>}
+				data={stats.canceledOrders.toString()}
+			/>
+		</section>
+	);
+}
+
+export function KoperVeilingStats() {
+	const {t} = useRootContext();
+	const [stats, setStats] = useState({
+		activeAuctions: 0,
+		scheduledAuctions: 0,
+		availableProducts: 0,
+		yourPurchases: 0
+	});
+
+	useEffect(() => {
+		const fetchStats = async () => {
+			try {
+				const response = await getKoperVeilingStats();
+				if (response.data) {
+					setStats(response.data);
+				}
+			} catch (error) {
+				console.error('Failed to fetch veiling stats:', error);
+			}
+		};
+
+		fetchStats();
+	}, []);
+
+	return (
+		<section className="kweker-stats meester-stats">
+			<StatsCard
+				title={t('active_auctions')}
+				icon={<i className="bi bi-clock-fill"></i>}
+				data={stats.activeAuctions.toString()}
+			/>
+
+			<StatsCard
+				title={t('scheduled_auctions')}
+				icon={<i className="bi bi-calendar-fill"></i>}
+				data={stats.scheduledAuctions.toString()}
+			/>
+
+			<StatsCard
+				title={t('available_products')}
+				icon={<i className="bi bi-bag-fill"></i>}
+				data={stats.availableProducts.toString()}
+			/>
+
+			<StatsCard
+				title={t('your_purchases')}
+				icon={<i className="bi bi-cart-check-fill"></i>}
+				data={stats.yourPurchases.toString()}
+			/>
+		</section>
+	);
+}

--- a/FrontendWeb/src/components/sections/kweker/DashboardSections.tsx
+++ b/FrontendWeb/src/components/sections/kweker/DashboardSections.tsx
@@ -1,0 +1,200 @@
+import React, {useEffect, useState} from 'react';
+import {useRootContext} from '../../contexts/RootContext';
+import {getOrders, getProducts} from '../../../controllers/server/kweker';
+import {OrderKwekerOutput} from '../../../declarations/dtos/output/OrderKwekerOutput';
+import {ProductOutputDto} from '../../../declarations/dtos/output/ProductOutputDto';
+import {OrderStatus} from '../../../declarations/enums/OrderStatus';
+
+export function RecentOrdersSection() {
+	const {t} = useRootContext();
+	const [orders, setOrders] = useState<OrderKwekerOutput[]>([]);
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		const fetchRecentOrders = async () => {
+			try {
+				const response = await getOrders(undefined, undefined, undefined, undefined, undefined, undefined, 1, 5);
+				if (response.success && response.data) {
+					setOrders(response.data.data);
+				}
+			} catch (error) {
+				console.error('Failed to fetch recent orders:', error);
+			} finally {
+				setLoading(false);
+			}
+		};
+
+		fetchRecentOrders();
+	}, []);
+
+	const getOrderStatusBadge = (status: OrderStatus) => {
+		const statusMap = {
+			[OrderStatus.Open]: { class: 'badge-info', text: 'Open' },
+			[OrderStatus.Processing]: { class: 'badge-warning', text: 'In behandeling' },
+			[OrderStatus.Processed]: { class: 'badge-success', text: 'Verwerkt' },
+			[OrderStatus.Delivered]: { class: 'badge-success', text: 'Geleverd' },
+			[OrderStatus.Cancelled]: { class: 'badge-danger', text: 'Geannuleerd' },
+			[OrderStatus.Returned]: { class: 'badge-warning', text: 'Geretourneerd' },
+		};
+		return statusMap[status] || { class: 'badge-secondary', text: 'Onbekend' };
+	};
+
+	if (loading) {
+		return (
+			<section className="kweker-dashboard-section">
+				<h2 className="section-title">Recente bestellingen</h2>
+				<p>Loading...</p>
+			</section>
+		);
+	}
+
+	return (
+		<section className="kweker-dashboard-section">
+			<div className="section-header">
+				<h2 className="section-title">Recente bestellingen</h2>
+				<a href="/kweker/orders" className="section-link">
+					Alle bestellingen <i className="bi bi-arrow-right"></i>
+				</a>
+			</div>
+			
+			{orders.length === 0 ? (
+				<div className="empty-state">
+					<i className="bi bi-inbox" style={{fontSize: '3rem', opacity: 0.3}}></i>
+					<p>Geen bestellingen gevonden</p>
+				</div>
+			) : (
+				<div className="orders-list">
+					{orders.map((order) => (
+						<div key={order.id} className="order-card">
+							<div className="order-header">
+								<div className="order-info">
+									<h3 className="order-product-name">{order.product.name}</h3>
+									<p className="order-buyer">
+										<i className="bi bi-person"></i> {order.koperInfo.firstName} {order.koperInfo.lastName}
+									</p>
+								</div>
+								<span className={`order-status-badge ${getOrderStatusBadge(order.status).class}`}>
+									{getOrderStatusBadge(order.status).text}
+								</span>
+							</div>
+							<div className="order-details">
+								<div className="order-detail-item">
+									<span className="detail-label">Datum:</span>
+									<span className="detail-value">
+										{new Date(order.createdAt).toLocaleDateString('nl-NL')}
+									</span>
+								</div>
+								<div className="order-detail-item">
+									<span className="detail-label">Totaal:</span>
+									<span className="detail-value order-total">
+										€ {order.totalPrice.toFixed(2)}
+									</span>
+								</div>
+							</div>
+						</div>
+					))}
+				</div>
+			)}
+		</section>
+	);
+}
+
+export function ProductsOverviewSection() {
+	const {t} = useRootContext();
+	const [products, setProducts] = useState<ProductOutputDto[]>([]);
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		const fetchProducts = async () => {
+			try {
+				const response = await getProducts(undefined, undefined, undefined, 1, 6);
+				if (response.success && response.data) {
+					setProducts(response.data.data);
+				}
+			} catch (error) {
+				console.error('Failed to fetch products:', error);
+			} finally {
+				setLoading(false);
+			}
+		};
+
+		fetchProducts();
+	}, []);
+
+	if (loading) {
+		return (
+			<section className="kweker-dashboard-section">
+				<h2 className="section-title">Mijn producten</h2>
+				<p>Loading...</p>
+			</section>
+		);
+	}
+
+	return (
+		<section className="kweker-dashboard-section">
+			<div className="section-header">
+				<h2 className="section-title">Mijn producten</h2>
+				<a href="/kweker/products" className="section-link">
+					Alle producten <i className="bi bi-arrow-right"></i>
+				</a>
+			</div>
+
+			{products.length === 0 ? (
+				<div className="empty-state">
+					<i className="bi bi-box" style={{fontSize: '3rem', opacity: 0.3}}></i>
+					<p>Nog geen producten toegevoegd</p>
+					<a href="/kweker/create-product" className="btn-primary" style={{marginTop: '1rem'}}>
+						<i className="bi bi-plus-circle"></i> Product toevoegen
+					</a>
+				</div>
+			) : (
+				<div className="products-grid">
+					{products.map((product) => (
+						<div key={product.id} className="product-card">
+							<div className="product-image-wrapper">
+								<img 
+									src={product.imageUrl || '/pictures/placeholder.jpg'} 
+									alt={product.name}
+									className="product-image"
+								/>
+								{product.auctionPlanned && (
+									<span className="product-badge auction-badge">
+										<i className="bi bi-clock"></i> Actief
+									</span>
+								)}
+							</div>
+							<div className="product-info">
+								<h3 className="product-name">{product.name}</h3>
+								<div className="product-details">
+									<div className="product-detail-row">
+										<span className="detail-label">
+											<i className="bi bi-tag"></i> Prijs:
+										</span>
+										<span className="detail-value">€ {(product.minimumPrice || 0).toFixed(2)}</span>
+									</div>
+									<div className="product-detail-row">
+										<span className="detail-label">
+											<i className="bi bi-box"></i> Voorraad:
+										</span>
+										<span className="detail-value">{product.stock}</span>
+									</div>
+									{product.region && (
+										<div className="product-detail-row">
+											<span className="detail-label">
+												<i className="bi bi-geo-alt"></i> Regio:
+											</span>
+											<span className="detail-value">{product.region}</span>
+										</div>
+									)}
+								</div>
+								<a href={`/kweker/product/${product.id}`} className="product-link">
+									Details bekijken <i className="bi bi-arrow-right"></i>
+								</a>
+							</div>
+						</div>
+					))}
+				</div>
+			)}
+		</section>
+	);
+}

--- a/FrontendWeb/src/components/sections/kweker/KwekerStats.tsx
+++ b/FrontendWeb/src/components/sections/kweker/KwekerStats.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import {useRootContext} from "../../contexts/RootContext";
+import {getKwekerStats, getKwekerProductStats, getKwekerOrderStats} from '../../../controllers/server/kweker';
+import {KwekerStatsOutputDto} from '../../../declarations/dtos/output/KwekerStatsOutputDto';
 
 type DashboardStatsProps = {
 	totalProducts?: number;
@@ -51,39 +53,58 @@ function StatsCard(props: StatsCardProps) {
 
 export function KwekerDashboardStats(props: DashboardStatsProps) {
 	const {t} = useRootContext();
+	const [stats, setStats] = useState<KwekerStatsOutputDto | null>(null);
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		const fetchStats = async () => {
+			try {
+				const response = await getKwekerStats();
+				if (response.data) {
+					setStats(response.data);
+				}
+			} catch (error) {
+				console.error('Failed to fetch kweker stats:', error);
+			} finally {
+				setLoading(false);
+			}
+		};
+
+		fetchStats();
+	}, []);
 
 	return (
 		<section className="kweker-stats">
 			<StatsCard
 				title={t('products_offered')}
 				icon={<i className="bi bi-bag-fill"></i>}
-				data={'1,500 €'}
-				enablePercentage
+				data={stats?.totalProducts.toString() || '0'}
+				enablePercentage={false}
 			/>
 
 			<StatsCard
-				title={t('products_sold')}
-				icon={<i className="bi bi-box-seam-fill"></i>}
-				data={'50'}
-				enablePercentage
+				title={t('active_auctions')}
+				icon={<i className="bi bi-clock-fill"></i>}
+				data={stats?.activeAuctions.toString() || '0'}
+				enablePercentage={false}
 			/>
 
 			<StatsCard
-				title={t('total_earnings')}
+				title={t('total_revenue')}
 				icon={<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1792 1792" height="20" fill="currentColor" width="20">
 					<path
 						d="M1362 1185q0 153-99.5 263.5t-258.5 136.5v175q0 14-9 23t-23 9h-135q-13 0-22.5-9.5t-9.5-22.5v-175q-66-9-127.5-31t-101.5-44.5-74-48-46.5-37.5-17.5-18q-17-21-2-41l103-135q7-10 23-12 15-2 24 9l2 2q113 99 243 125 37 8 74 8 81 0 142.5-43t61.5-122q0-28-15-53t-33.5-42-58.5-37.5-66-32-80-32.5q-39-16-61.5-25t-61.5-26.5-62.5-31-56.5-35.5-53.5-42.5-43.5-49-35.5-58-21-66.5-8.5-78q0-138 98-242t255-134v-180q0-13 9.5-22.5t22.5-9.5h135q14 0 23 9t9 23v176q57 6 110.5 23t87 33.5 63.5 37.5 39 29 15 14q17 18 5 38l-81 146q-8 15-23 16-14 3-27-7-3-3-14.5-12t-39-26.5-58.5-32-74.5-26-85.5-11.5q-95 0-155 43t-60 111q0 26 8.5 48t29.5 41.5 39.5 33 56 31 60.5 27 70 27.5q53 20 81 31.5t76 35 75.5 42.5 62 50 53 63.5 31.5 76.5 13 94z">
 					</path>
 				</svg>}
-				data={'1,500 €'}
-				enablePercentage
+				data={`€ ${stats?.totalRevenue.toFixed(2) || '0.00'}`}
+				enablePercentage={false}
 			/>
 
 			<StatsCard
-				title={t('plants_sold')}
-				icon={<i className="bi bi-flower3"></i>}
-				data={'1.000'}
-				enablePercentage
+				title={t('orders_received')}
+				icon={<i className="bi bi-cart-check-fill"></i>}
+				data={stats?.ordersReceived.toString() || '0'}
+				enablePercentage={false}
 			/>
 		</section>
 	);
@@ -92,25 +113,45 @@ export function KwekerDashboardStats(props: DashboardStatsProps) {
 
 export function KwekerProductStats() {
 	const {t} = useRootContext();
+	const [stats, setStats] = useState({
+		totalProducts: 0,
+		inventoryStock: 0,
+		activeAuctions: 0
+	});
+
+	useEffect(() => {
+		const fetchStats = async () => {
+			try {
+				const response = await getKwekerProductStats();
+				if (response.data) {
+					setStats(response.data);
+				}
+			} catch (error) {
+				console.error('Failed to fetch product stats:', error);
+			}
+		};
+
+		fetchStats();
+	}, []);
 
 	return (
 		<section className="kweker-stats kweker-product-stats">
 			<StatsCard
 				title={t('total_products')}
 				icon={<i className="bi bi-bag-fill"></i>}
-				data={'1,500'}
+				data={stats.totalProducts.toString()}
 			/>
 
 			<StatsCard
 				title={t('inventory_stock')}
 				icon={<i className="bi bi-box-fill"></i>}
-				data={'150'}
+				data={stats.inventoryStock.toString()}
 			/>
 
 			<StatsCard
 				title={t('active_auctions')}
 				icon={<i className="bi bi bi-clock-fill"></i>}
-				data={'150'}
+				data={stats.activeAuctions.toString()}
 			/>
 		</section>
 	);
@@ -118,31 +159,52 @@ export function KwekerProductStats() {
 
 export function KwekerOrderStats() {
 	const {t} = useRootContext();
+	const [stats, setStats] = useState({
+		totalOrders: 0,
+		pendingOrders: 0,
+		completedOrders: 0,
+		canceledOrders: 0
+	});
+
+	useEffect(() => {
+		const fetchStats = async () => {
+			try {
+				const response = await getKwekerOrderStats();
+				if (response.data) {
+					setStats(response.data);
+				}
+			} catch (error) {
+				console.error('Failed to fetch order stats:', error);
+			}
+		};
+
+		fetchStats();
+	}, []);
 
 	return (
 		<section className="kweker-stats">
 			<StatsCard
 				title={t('total_orders')}
 				icon={<i className="bi bi-cart-fill"></i>}
-				data={'1,500'}
+				data={stats.totalOrders.toString()}
 			/>
 
 			<StatsCard
 				title={t('pending_orders')}
 				icon={<i className="bi bi-clock-fill"></i>}
-				data={'150'}
+				data={stats.pendingOrders.toString()}
 			/>
 
 			<StatsCard
 				title={t('completed_orders')}
 				icon={<i className="bi bi-check-circle-fill"></i>}
-				data={'1,200'}
+				data={stats.completedOrders.toString()}
 			/>
 
 			<StatsCard
 				title={t('canceled_orders')}
 				icon={<i className="bi bi-x-circle-fill"></i>}
-				data={'50'}
+				data={stats.canceledOrders.toString()}
 			/>
 		</section>
 	);

--- a/FrontendWeb/src/components/sections/kweker/RevenueChart.tsx
+++ b/FrontendWeb/src/components/sections/kweker/RevenueChart.tsx
@@ -1,0 +1,214 @@
+import React, {useEffect, useState} from 'react';
+import {useRootContext} from '../../contexts/RootContext';
+import {getKwekerStats} from '../../../controllers/server/kweker';
+import {MonthlyRevenueDto} from '../../../declarations/dtos/output/KwekerStatsOutputDto';
+
+export function RevenueChart() {
+	const {t} = useRootContext();
+	const [monthlyData, setMonthlyData] = useState<MonthlyRevenueDto[]>([]);
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		const fetchData = async () => {
+			try {
+				const response = await getKwekerStats();
+				if (response.success && response.data) {
+					setMonthlyData(response.data.monthlyRevenue);
+				}
+			} catch (error) {
+				console.error('Failed to fetch revenue data:', error);
+			} finally {
+				setLoading(false);
+			}
+		};
+
+		fetchData();
+	}, []);
+
+	if (loading) {
+		return (
+			<section className="kweker-dashboard-section revenue-chart-section">
+				<h2 className="section-title">Inkomsten overzicht</h2>
+				<div className="chart-loading">
+					<p>Loading...</p>
+				</div>
+			</section>
+		);
+	}
+
+	if (monthlyData.length === 0) {
+		return (
+			<section className="kweker-dashboard-section revenue-chart-section">
+				<h2 className="section-title">Inkomsten overzicht</h2>
+				<div className="empty-state">
+					<i className="bi bi-graph-up" style={{fontSize: '3rem', opacity: 0.3}}></i>
+					<p>Nog geen inkomsten data beschikbaar</p>
+				</div>
+			</section>
+		);
+	}
+
+	// Calculate chart dimensions and scales
+	const maxRevenue = Math.max(...monthlyData.map(d => d.revenue), 100);
+	const chartWidth = 900;
+	const chartHeight = 300;
+	const padding = { top: 20, right: 20, bottom: 60, left: 70 };
+	const innerWidth = chartWidth - padding.left - padding.right;
+	const innerHeight = chartHeight - padding.top - padding.bottom;
+
+	// Create points for the line
+	const points = monthlyData.map((data, index) => {
+		const x = padding.left + (index / (monthlyData.length - 1)) * innerWidth;
+		const y = padding.top + innerHeight - (data.revenue / maxRevenue) * innerHeight;
+		return { x, y, data };
+	});
+
+	// Create path for area fill
+	const areaPath = `
+		M ${padding.left} ${padding.top + innerHeight}
+		${points.map(p => `L ${p.x} ${p.y}`).join(' ')}
+		L ${padding.left + innerWidth} ${padding.top + innerHeight}
+		Z
+	`;
+
+	// Create path for line
+	const linePath = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ');
+
+	// Y-axis labels
+	const yAxisSteps = 5;
+	const yAxisLabels = Array.from({length: yAxisSteps + 1}, (_, i) => {
+		const value = (maxRevenue / yAxisSteps) * i;
+		return {
+			value,
+			y: padding.top + innerHeight - (i / yAxisSteps) * innerHeight
+		};
+	});
+
+	return (
+		<section className="kweker-dashboard-section revenue-chart-section">
+			<div className="section-header">
+				<h2 className="section-title">Inkomsten overzicht</h2>
+				<div className="chart-legend">
+					<span className="legend-item">
+						<span className="legend-color" style={{backgroundColor: '#10b981'}}></span>
+						Laatste 12 maanden
+					</span>
+				</div>
+			</div>
+
+			<div className="chart-container" style={{backgroundColor: 'white'}}>
+				<svg viewBox={`0 0 ${chartWidth} ${chartHeight}`} className="revenue-chart" style={{backgroundColor: 'white'}}>
+					{/* White background */}
+					<rect x="0" y="0" width={chartWidth} height={chartHeight} fill="white" />
+					
+					{/* Grid lines */}
+					{yAxisLabels.map((label, i) => (
+						<line
+							key={i}
+							x1={padding.left}
+							y1={label.y}
+							x2={chartWidth - padding.right}
+							y2={label.y}
+							stroke="#e5e7eb"
+							strokeWidth="1"
+						/>
+					))}
+
+					{/* Y-axis labels */}
+					{yAxisLabels.map((label, i) => (
+						<text
+							key={i}
+							x={padding.left - 10}
+							y={label.y + 4}
+							textAnchor="end"
+							className="chart-label"
+						>
+							€{label.value.toFixed(0)}
+						</text>
+					))}
+
+					{/* Area fill */}
+					<path
+						d={areaPath}
+						fill="url(#gradient)"
+						opacity="0.3"
+					/>
+
+					{/* Line */}
+					<path
+						d={linePath}
+						fill="none"
+						stroke="#10b981"
+						strokeWidth="3"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+					/>
+
+					{/* Data points */}
+					{points.map((point, i) => (
+						<g key={i}>
+							<circle
+								cx={point.x}
+								cy={point.y}
+								r="5"
+								fill="#10b981"
+								className="chart-point"
+							/>
+							<title>
+								{point.data.monthName}: €{point.data.revenue.toFixed(2)}
+							</title>
+						</g>
+					))}
+
+					{/* X-axis labels */}
+					{points.map((point, i) => {
+						// Show every other label to avoid crowding
+						if (i % 2 === 0 || i === points.length - 1) {
+							return (
+								<text
+									key={i}
+									x={point.x}
+									y={chartHeight - padding.bottom + 20}
+									textAnchor="middle"
+									className="chart-label"
+								>
+									{point.data.monthName}
+								</text>
+							);
+						}
+						return null;
+					})}
+
+					{/* Gradient definition */}
+					<defs>
+						<linearGradient id="gradient" x1="0%" y1="0%" x2="0%" y2="100%">
+							<stop offset="0%" stopColor="#10b981" stopOpacity="0.8" />
+							<stop offset="100%" stopColor="#10b981" stopOpacity="0.1" />
+						</linearGradient>
+					</defs>
+				</svg>
+			</div>
+
+			<div className="chart-summary">
+				<div className="summary-item">
+					<span className="summary-label">Hoogste maand:</span>
+					<span className="summary-value">
+						€{Math.max(...monthlyData.map(d => d.revenue)).toFixed(2)}
+					</span>
+				</div>
+				<div className="summary-item">
+					<span className="summary-label">Gemiddelde per maand:</span>
+					<span className="summary-value">
+						€{(monthlyData.reduce((sum, d) => sum + d.revenue, 0) / monthlyData.length).toFixed(2)}
+					</span>
+				</div>
+				<div className="summary-item">
+					<span className="summary-label">Totaal (12 maanden):</span>
+					<span className="summary-value">
+						€{monthlyData.reduce((sum, d) => sum + d.revenue, 0).toFixed(2)}
+					</span>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/FrontendWeb/src/components/sections/meester/MeesterStats.tsx
+++ b/FrontendWeb/src/components/sections/meester/MeesterStats.tsx
@@ -1,0 +1,144 @@
+import React, {useEffect, useState} from 'react';
+import {useRootContext} from '../../contexts/RootContext';
+import {getMeesterStats} from '../../../controllers/server/veilingmeester';
+
+type StatsCardProps = {
+	title: string;
+	icon: React.ReactNode;
+	data: string;
+	percentage?: number;
+	enablePercentage?: boolean;
+}
+
+function StatsCard(props: StatsCardProps) {
+	const {t} = useRootContext();
+	const {title, icon, data, enablePercentage, percentage = 0.00} = props;
+	return (
+		<div className="kweker-stat-card">
+			<div className="kweker-stat-title">
+		        <span>
+			        {icon}
+ 				</span>
+				<p className="products-page-action-card-txt">
+					{title}
+				</p>
+			</div>
+			<div className="kweker-stat-data">
+				<p>
+					{data}
+				</p>
+			</div>
+
+			{
+				enablePercentage && (<div className="kweker-stat-row">
+				<span className="kweker-stat-label">
+					<p>
+						+{percentage}%
+					</p>
+				</span>
+					<span className="kweker-stat-row-txt"> {t('this_month')}</span>
+				</div>)
+			}
+		</div>
+	);
+}
+
+export function MeesterStats() {
+	const {t} = useRootContext();
+	const [stats, setStats] = useState({
+		totalVeilingKlokken: 0,
+		activeVeilingKlokken: 0,
+		totalProducts: 0,
+		totalOrders: 0
+	});
+
+	useEffect(() => {
+		const fetchStats = async () => {
+			try {
+				const response = await getMeesterStats();
+				if (response.data) {
+					setStats(response.data);
+				}
+			} catch (error) {
+				console.error('Failed to fetch meester stats:', error);
+			}
+		};
+
+		fetchStats();
+	}, []);
+
+	return (
+		<section className="kweker-stats meester-stats">
+			<StatsCard
+				title={t('total_veilingklokken')}
+				icon={<i className="bi bi-clock-fill"></i>}
+				data={stats.totalVeilingKlokken.toString()}
+			/>
+
+			<StatsCard
+				title={t('active_veilingklokken')}
+				icon={<i className="bi bi-clock-history"></i>}
+				data={stats.activeVeilingKlokken.toString()}
+			/>
+
+			<StatsCard
+				title={t('total_products')}
+				icon={<i className="bi bi-bag-fill"></i>}
+				data={stats.totalProducts.toString()}
+			/>
+
+			<StatsCard
+				title={t('total_orders')}
+				icon={<i className="bi bi-cart-fill"></i>}
+				data={stats.totalOrders.toString()}
+			/>
+		</section>
+	);
+}
+
+export function MeesterProductStats() {
+	const {t} = useRootContext();
+	const [stats, setStats] = useState({
+		totalVeilingKlokken: 0,
+		activeVeilingKlokken: 0,
+		totalProducts: 0,
+		totalOrders: 0
+	});
+
+	useEffect(() => {
+		const fetchStats = async () => {
+			try {
+				const response = await getMeesterStats();
+				if (response.data) {
+					setStats(response.data);
+				}
+			} catch (error) {
+				console.error('Failed to fetch meester stats:', error);
+			}
+		};
+
+		fetchStats();
+	}, []);
+
+	return (
+		<section className="kweker-stats kweker-product-stats">
+			<StatsCard
+				title={t('total_products')}
+				icon={<i className="bi bi-bag-fill"></i>}
+				data={stats.totalProducts.toString()}
+			/>
+
+			<StatsCard
+				title={t('total_orders')}
+				icon={<i className="bi bi-cart-fill"></i>}
+				data={stats.totalOrders.toString()}
+			/>
+
+			<StatsCard
+				title={t('active_veilingklokken')}
+				icon={<i className="bi bi-clock-fill"></i>}
+				data={stats.activeVeilingKlokken.toString()}
+			/>
+		</section>
+	);
+}

--- a/FrontendWeb/src/controllers/server/koper.ts
+++ b/FrontendWeb/src/controllers/server/koper.ts
@@ -14,6 +14,8 @@ import {OrderItemOutputDto} from '../../declarations/dtos/output/OrderItemOutput
 import {ProductOutputDto} from '../../declarations/dtos/output/ProductOutputDto';
 import {VeilingKlokOutputDto} from '../../declarations/dtos/output/VeilingKlokOutputDto';
 import {VeilingKlokStatus} from "../../declarations/enums/VeilingKlokStatus";
+import {KoperStatsOutputDto} from '../../declarations/dtos/output/KoperStatsOutputDto';
+import {KoperVeilingStatsOutputDto} from '../../declarations/dtos/output/KoperVeilingStatsOutputDto';
 
 // Create koper account (POST /api/account/koper/create)
 export async function createKoperAccount(account: CreateKoperDTO): Promise<HttpSuccess<AuthOutputDto>> {
@@ -28,6 +30,20 @@ export async function updateKoperAccount(account: UpdateKoperDTO): Promise<HttpS
 	return fetchResponse<HttpSuccess<AccountOutputDto>>('/api/account/koper/update', {
 		method: 'POST',
 		body: JSON.stringify(account),
+	});
+}
+
+// Get koper stats (GET /api/account/koper/stats)
+export async function getKoperStats(): Promise<HttpSuccess<KoperStatsOutputDto>> {
+	return fetchResponse<HttpSuccess<KoperStatsOutputDto>>('/api/account/koper/stats', {
+		method: 'GET',
+	});
+}
+
+// Get koper veiling stats (GET /api/account/koper/veiling-stats)
+export async function getKoperVeilingStats(): Promise<HttpSuccess<KoperVeilingStatsOutputDto>> {
+	return fetchResponse<HttpSuccess<KoperVeilingStatsOutputDto>>('/api/account/koper/veiling-stats', {
+		method: 'GET',
 	});
 }
 

--- a/FrontendWeb/src/controllers/server/kweker.ts
+++ b/FrontendWeb/src/controllers/server/kweker.ts
@@ -13,6 +13,8 @@ import { PaginatedOutputDto } from '../../declarations/dtos/output/PaginatedOutp
 import { ProductOutputDto } from '../../declarations/dtos/output/ProductOutputDto';
 import { VeilingKlokOutputDto } from '../../declarations/dtos/output/VeilingKlokOutputDto';
 import { KwekerStatsOutputDto } from '../../declarations/dtos/output/KwekerStatsOutputDto';
+import { KwekerProductStatsOutputDto } from '../../declarations/dtos/output/KwekerProductStatsOutputDto';
+import { KwekerOrderStatsOutputDto } from '../../declarations/dtos/output/KwekerOrderStatsOutputDto';
 import { OrderStatus } from '../../declarations/enums/OrderStatus';
 import { getOrderStatusString } from '../../utils/standards';
 
@@ -119,4 +121,14 @@ export async function getVeilingKlok(klokId: string): Promise<HttpSuccess<Veilin
 // Get kweker stats (GET /api/account/kweker/stats)
 export async function getKwekerStats(): Promise<HttpSuccess<KwekerStatsOutputDto>> {
 	return fetchResponse<HttpSuccess<KwekerStatsOutputDto>>('/api/account/kweker/stats');
+}
+
+// Get kweker product stats (GET /api/account/kweker/product-stats)
+export async function getKwekerProductStats(): Promise<HttpSuccess<KwekerProductStatsOutputDto>> {
+	return fetchResponse<HttpSuccess<KwekerProductStatsOutputDto>>('/api/account/kweker/product-stats');
+}
+
+// Get kweker order stats (GET /api/account/kweker/order-stats)
+export async function getKwekerOrderStats(): Promise<HttpSuccess<KwekerOrderStatsOutputDto>> {
+	return fetchResponse<HttpSuccess<KwekerOrderStatsOutputDto>>('/api/account/kweker/order-stats');
 }

--- a/FrontendWeb/src/controllers/server/veilingmeester.ts
+++ b/FrontendWeb/src/controllers/server/veilingmeester.ts
@@ -12,6 +12,7 @@ import {ProductDetailsOutputDto} from '../../declarations/dtos/output/ProductDet
 import {PaginatedOutputDto} from '../../declarations/dtos/output/PaginatedOutputDto';
 import {ProductOutputDto} from '../../declarations/dtos/output/ProductOutputDto';
 import {VeilingKlokStatus} from '../../declarations/enums/VeilingKlokStatus';
+import {MeesterStatsOutputDto} from '../../declarations/dtos/output/MeesterStatsOutputDto';
 
 // Create veilingmeester account (POST /api/account/meester/create)
 export async function createVeilingmeesterAccount(account: CreateMeesterDTO): Promise<HttpSuccess<AuthOutputDto>> {
@@ -26,6 +27,13 @@ export async function updateVeilingmeesterAccount(account: UpdateVeilingMeesterD
 	return fetchResponse<HttpSuccess<AccountOutputDto>>('/api/account/meester/update', {
 		method: 'POST',
 		body: JSON.stringify(account),
+	});
+}
+
+// Get meester stats (GET /api/account/meester/stats)
+export async function getMeesterStats(): Promise<HttpSuccess<MeesterStatsOutputDto>> {
+	return fetchResponse<HttpSuccess<MeesterStatsOutputDto>>('/api/account/meester/stats', {
+		method: 'GET',
 	});
 }
 

--- a/FrontendWeb/src/controllers/services/localization.ts
+++ b/FrontendWeb/src/controllers/services/localization.ts
@@ -249,7 +249,7 @@ export const resources = {
 			no_products: 'Geen product gevonden',
 
 			// ===== VEILINGMEESTER DASHBOARD =====
-			total_veilingklokken: 'Totaal veilingklokken',
+			total_veilingklokken: 'Totaal aantal veilingklokken',
 			active_veilingklokken: 'Actieve veilingklokken',
 			scheduled_auctions: 'Geplande veilingen',
 			available_products: 'Beschikbare producten',

--- a/FrontendWeb/src/controllers/services/localization.ts
+++ b/FrontendWeb/src/controllers/services/localization.ts
@@ -225,8 +225,8 @@ export const resources = {
 			active_auctions: 'Actieve veilingen',
 			total_revenue: 'Totale inkomsten',
 			orders_received: 'Orders ontvangen',
-			total_products: 'Totaal producten',
-			inventory_stock: 'Totaal voorraad',
+			total_products: 'Aantal producten',
+			inventory_stock: 'Totale voorraad',
 
 			// ===== KWEKER ORDERS =====
 			total_orders: 'Totaal bestellingen',

--- a/FrontendWeb/src/controllers/services/localization.ts
+++ b/FrontendWeb/src/controllers/services/localization.ts
@@ -222,10 +222,9 @@ export const resources = {
 			kweker_stats_change: '+0.00%',
 			kweker_stats_this_month: 'Deze maand',
 			products_offered: 'Producten aangeboden',
-			products_sold: 'Producten verkocht',
-			total_earnings: 'Totale verdiensten',
-			plants_sold: 'Bloemstelen verkocht',
 			active_auctions: 'Actieve veilingen',
+			total_revenue: 'Totale inkomsten',
+			orders_received: 'Orders ontvangen',
 			total_products: 'Totaal producten',
 			inventory_stock: 'Totaal voorraad',
 

--- a/FrontendWeb/src/controllers/services/localization.ts
+++ b/FrontendWeb/src/controllers/services/localization.ts
@@ -171,6 +171,7 @@ export const resources = {
 			kweker_welcome: 'Welkom, {{firstName}} {{lastName}}!',
 			kweker_desc: 'Welkom op de dashboard pagina! Bekijk hier uw producten!',
 			kweker_products_description: 'Beheer uw producten en voorraden efficiënt',
+			koper_products_description: 'Bekijk hier alle aangeboden bloemen!',
 			kweker_orders_description: 'Overzicht en beheer van uw bestellingen',
 			kweker_section_products: 'Producten',
 
@@ -229,7 +230,7 @@ export const resources = {
 			inventory_stock: 'Totale voorraad',
 
 			// ===== KWEKER ORDERS =====
-			total_orders: 'Totaal bestellingen',
+			total_orders: 'Totaal aantal bestellingen',
 			pending_orders: 'Openstaande bestellingen',
 			completed_orders: 'Voltooide bestellingen',
 			canceled_orders: 'Geannuleerde bestellingen',
@@ -248,6 +249,12 @@ export const resources = {
 			no_products: 'Geen product gevonden',
 
 			// ===== VEILINGMEESTER DASHBOARD =====
+			total_veilingklokken: 'Totaal veilingklokken',
+			active_veilingklokken: 'Actieve veilingklokken',
+			scheduled_auctions: 'Geplande veilingen',
+			available_products: 'Beschikbare producten',
+			available_flowers: 'Beschikbare bloemen',
+			your_purchases: 'Jouw aankopen',
 			vm_title: 'Veilingmeester',
 			vm_tab_auction: 'Veiling',
 			vm_tab_history: 'History',

--- a/FrontendWeb/src/declarations/dtos/output/KoperStatsOutputDto.ts
+++ b/FrontendWeb/src/declarations/dtos/output/KoperStatsOutputDto.ts
@@ -1,0 +1,7 @@
+// KoperStatsOutputDto.ts
+export interface KoperStatsOutputDto {
+	totalOrders: number;
+	pendingOrders: number;
+	completedOrders: number;
+	canceledOrders: number;
+}

--- a/FrontendWeb/src/declarations/dtos/output/KoperVeilingStatsOutputDto.ts
+++ b/FrontendWeb/src/declarations/dtos/output/KoperVeilingStatsOutputDto.ts
@@ -1,0 +1,7 @@
+// KoperVeilingStatsOutputDto.ts
+export interface KoperVeilingStatsOutputDto {
+	activeAuctions: number;
+	scheduledAuctions: number;
+	availableProducts: number;
+	yourPurchases: number;
+}

--- a/FrontendWeb/src/declarations/dtos/output/KwekerOrderStatsOutputDto.ts
+++ b/FrontendWeb/src/declarations/dtos/output/KwekerOrderStatsOutputDto.ts
@@ -1,0 +1,6 @@
+export interface KwekerOrderStatsOutputDto {
+    totalOrders: number;
+    pendingOrders: number;
+    completedOrders: number;
+    canceledOrders: number;
+}

--- a/FrontendWeb/src/declarations/dtos/output/KwekerProductStatsOutputDto.ts
+++ b/FrontendWeb/src/declarations/dtos/output/KwekerProductStatsOutputDto.ts
@@ -1,0 +1,5 @@
+export interface KwekerProductStatsOutputDto {
+    totalProducts: number;
+    inventoryStock: number;
+    activeAuctions: number;
+}

--- a/FrontendWeb/src/declarations/dtos/output/KwekerStatsOutputDto.ts
+++ b/FrontendWeb/src/declarations/dtos/output/KwekerStatsOutputDto.ts
@@ -5,11 +5,20 @@ export interface KwekerStatsOutputDto {
 	totalRevenue: number;
 	ordersReceived: number;
 	monthlyRevenue: MonthlyRevenueDto[];
+	dailyRevenue: DailyRevenueDto[];
 }
 
 export interface MonthlyRevenueDto {
 	year: number;
 	month: number;
 	monthName: string;
+	revenue: number;
+}
+
+export interface DailyRevenueDto {
+	year: number;
+	month: number;
+	day: number;
+	dateLabel: string;
 	revenue: number;
 }

--- a/FrontendWeb/src/declarations/dtos/output/KwekerStatsOutputDto.ts
+++ b/FrontendWeb/src/declarations/dtos/output/KwekerStatsOutputDto.ts
@@ -3,5 +3,13 @@ export interface KwekerStatsOutputDto {
 	totalProducts: number;
 	activeAuctions: number;
 	totalRevenue: number;
-	stemsSold: number;
+	ordersReceived: number;
+	monthlyRevenue: MonthlyRevenueDto[];
+}
+
+export interface MonthlyRevenueDto {
+	year: number;
+	month: number;
+	monthName: string;
+	revenue: number;
 }

--- a/FrontendWeb/src/declarations/dtos/output/MeesterStatsOutputDto.ts
+++ b/FrontendWeb/src/declarations/dtos/output/MeesterStatsOutputDto.ts
@@ -1,0 +1,7 @@
+// MeesterStatsOutputDto.ts
+export interface MeesterStatsOutputDto {
+	totalVeilingKlokken: number;
+	activeVeilingKlokken: number;
+	totalProducts: number;
+	totalOrders: number;
+}

--- a/FrontendWeb/src/pages/koper/KoperOrders.tsx
+++ b/FrontendWeb/src/pages/koper/KoperOrders.tsx
@@ -10,7 +10,7 @@ import { getOrders } from '../../controllers/server/koper';
 import html2canvas from 'html2canvas';
 import jsPDF from 'jspdf';
 import Page from '../../components/nav/Page';
-import { KwekerOrderStats } from '../../components/sections/kweker/KwekerStats';
+import { KoperStats } from '../../components/sections/koper/KoperStats';
 import Modal from '../../components/elements/Modal';
 import { OrderOutputDto } from '../../declarations/dtos/output/OrderOutputDto';
 
@@ -174,7 +174,7 @@ function KoperOrders() {
 					<h2>{t('kweker_orders_description')}</h2>
 				</section>
 
-				<KwekerOrderStats />
+				<KoperStats />
 
 				<DataTable<OrderOutputDto>
 					isLazy

--- a/FrontendWeb/src/pages/koper/KoperProducts.tsx
+++ b/FrontendWeb/src/pages/koper/KoperProducts.tsx
@@ -43,7 +43,7 @@ function KoperProducts() {
 						{t('welcome')}, {account?.firstName} {account?.lastName}
 					</h1>
 					<h2>
-						{t('kweker_products_description')}
+						{t('koper_products_description')}
 					</h2>
 				</section>
 
@@ -55,7 +55,7 @@ function KoperProducts() {
 					totalItems={paginatedProducts?.totalCount || 0}
 					onFetchData={handleFetchProducts}
 
-					title={t('your_products')}
+					title={t('available_flowers')}
 					icon={<i className="bi bi-bag-fill"></i>}
 					renderItem={(item, index) => (
 						<ProductCard

--- a/FrontendWeb/src/pages/koper/KoperVeilingKlokken.tsx
+++ b/FrontendWeb/src/pages/koper/KoperVeilingKlokken.tsx
@@ -7,7 +7,7 @@ import {Column, DataTable, OnFetchHandlerParams} from "../../components/layout/T
 import {getVeilingKlokken} from "../../controllers/server/koper";
 import {KlokStatusBadge} from "../../components/elements/StatusBadge";
 import Page from "../../components/nav/Page";
-import {KwekerProductStats} from "../../components/sections/kweker/KwekerStats";
+import {KoperVeilingStats} from "../../components/sections/koper/KoperStats";
 
 function KoperVeilingKlokken() {
 	const {t, account, languageCode, navigate} = useRootContext();
@@ -106,7 +106,7 @@ function KoperVeilingKlokken() {
 				</section>
 
 				<section className={'products-page-stats'}>
-					<KwekerProductStats/>
+					<KoperVeilingStats/>
 				</section>
 
 				<DataTable<VeilingKlokOutputDto>

--- a/FrontendWeb/src/pages/kweker/KwekerDashboard.tsx
+++ b/FrontendWeb/src/pages/kweker/KwekerDashboard.tsx
@@ -6,6 +6,7 @@ import {useRootContext} from '../../components/contexts/RootContext';
 
 // Components
 import {KwekerDashboardStats} from '../../components/sections/kweker/KwekerStats';
+import {RevenueChart} from '../../components/sections/kweker/RevenueChart';
 import Page from '../../components/nav/Page';
 
 
@@ -19,9 +20,12 @@ function KwekerDashboard() {
 					<h1>
 						{t('welcome')}, {account?.firstName} {account?.lastName}
 					</h1>
+					<p className="page-subtitle">{t('kweker_desc')}</p>
 				</section>
 
 				<KwekerDashboardStats/>
+
+				<RevenueChart/>
 			</main>
 		</Page>
 	);

--- a/FrontendWeb/src/pages/meester/VeilingmeesterHome.tsx
+++ b/FrontendWeb/src/pages/meester/VeilingmeesterHome.tsx
@@ -8,7 +8,7 @@ import {getVeilingKlokken} from "../../controllers/server/veilingmeester";
 import {KlokStatusBadge} from "../../components/elements/StatusBadge";
 import Page from "../../components/nav/Page";
 import CreateVeilingKlok from "../../components/sections/veiling-dashboard/CreateVeilingKlok";
-import {KwekerProductStats} from "../../components/sections/kweker/KwekerStats";
+import {MeesterStats} from "../../components/sections/meester/MeesterStats";
 
 function VeilingmeesterManageHome() {
 	const {t, account, languageCode, navigate} = useRootContext();
@@ -108,7 +108,7 @@ function VeilingmeesterManageHome() {
 				</section>
 
 				<section className={'products-page-stats'}>
-					<KwekerProductStats/>
+					<MeesterStats/>
 				</section>
 
 				<DataTable<VeilingKlokOutputDto>

--- a/FrontendWeb/src/pages/meester/VeilingmeesterProducts.tsx
+++ b/FrontendWeb/src/pages/meester/VeilingmeesterProducts.tsx
@@ -6,7 +6,7 @@ import {ProductOutputDto} from "../../declarations/dtos/output/ProductOutputDto"
 import {OnFetchHandlerParams} from "../../components/layout/Table";
 import {getProducts} from "../../controllers/server/veilingmeester";
 import Page from "../../components/nav/Page";
-import {KwekerProductStats} from "../../components/sections/kweker/KwekerStats";
+import {MeesterProductStats} from "../../components/sections/meester/MeesterStats";
 import Button from "../../components/buttons/Button";
 import GridTable from "../../components/layout/GridTable";
 import ProductCard from "../../components/cards/ProductCard";
@@ -52,7 +52,7 @@ function VeilingmeesterProducts() {
 					</h2>
 				</section>
 				<section className={'products-page-stats'}>
-					<KwekerProductStats/>
+					<MeesterProductStats/>
 
 					<div className="products-page-action-card">
 						<div className="products-page-action-card-title">

--- a/FrontendWeb/src/styles/components.css
+++ b/FrontendWeb/src/styles/components.css
@@ -720,6 +720,14 @@
     flex: 5;
 }
 
+.meester-stats {
+    flex: 5;
+}
+
+.meester-stats .kweker-stat-card {
+    max-width: 30%;
+}
+
 .kweker-stat-card {
     padding: 1rem 1.6rem;
     background-color: #fff;

--- a/FrontendWeb/src/styles/components.css
+++ b/FrontendWeb/src/styles/components.css
@@ -853,6 +853,366 @@
 
 /*#endregion*/
 
+/*#region Revenue Chart*/
+.revenue-chart-section {
+    grid-column: 1 / -1;
+    margin-top: 1rem;
+    background-color: #ffffff !important;
+}
+
+.revenue-chart-section .chart-container {
+    background-color: #ffffff !important;
+}
+
+.revenue-chart-section .empty-state {
+    background: #ffffff !important;
+    border: 1px dashed rgba(0, 0, 0, 0.12) !important;
+}
+
+.chart-container {
+    width: 100%;
+    margin: 1.5rem 0;
+    overflow-x: auto;
+    background-color: #ffffff !important;
+}
+
+.revenue-chart {
+    width: 100%;
+    height: auto;
+    min-width: 600px;
+    background-color: #ffffff !important;
+}
+
+.chart-label {
+    font-size: 12px;
+    fill: theme(colors.gray.600);
+}
+
+.chart-point {
+    cursor: pointer;
+    transition: r 0.2s;
+}
+
+.chart-point:hover {
+    r: 7;
+}
+
+.chart-legend {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    color: theme(colors.gray.700);
+}
+
+.legend-color {
+    width: 16px;
+    height: 16px;
+    border-radius: 4px;
+}
+
+.chart-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2rem;
+    padding: 1.5rem;
+    background-color: theme(colors.gray.50);
+    border-radius: 12px;
+    margin-top: 1rem;
+}
+
+.summary-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.summary-label {
+    font-size: 0.85rem;
+    color: theme(colors.gray.600);
+}
+
+.summary-value {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: theme(colors.primary.600);
+}
+
+.chart-loading {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 3rem;
+    color: theme(colors.gray.500);
+}
+
+/*#endregion*/
+
+/*#region Dashboard Sections*/
+.dashboard-content-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 2rem;
+    margin-top: 2rem;
+}
+
+@media (min-width: 1024px) {
+    .dashboard-content-grid {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+.kweker-dashboard-section {
+    background-color: #fff;
+    border-radius: 20px;
+    padding: 1.5rem;
+    border: solid 1px theme(colors.gray.200);
+}
+
+.section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+}
+
+.section-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #1F2937;
+}
+
+.section-link {
+    color: theme(colors.primary.500);
+    font-size: 0.95rem;
+    font-weight: 600;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    transition: color 0.2s;
+}
+
+.section-link:hover {
+    color: theme(colors.primary.700);
+}
+
+.page-subtitle {
+    color: theme(colors.gray.600);
+    font-size: 1rem;
+    margin-top: 0.5rem;
+}
+
+.empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 3rem 1rem;
+    color: theme(colors.gray.500);
+    text-align: center;
+}
+
+.orders-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.order-card {
+    border: 1px solid theme(colors.gray.200);
+    border-radius: 12px;
+    padding: 1rem;
+    transition: box-shadow 0.2s;
+}
+
+.order-card:hover {
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+}
+
+.order-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 0.75rem;
+}
+
+.order-info {
+    flex: 1;
+}
+
+.order-product-name {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #1F2937;
+    margin-bottom: 0.25rem;
+}
+
+.order-buyer {
+    font-size: 0.9rem;
+    color: theme(colors.gray.600);
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+}
+
+.order-status-badge {
+    padding: 0.25rem 0.75rem;
+    border-radius: 9999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.badge-info {
+    background-color: theme(colors.blue.100);
+    color: theme(colors.blue.700);
+}
+
+.badge-warning {
+    background-color: theme(colors.yellow.100);
+    color: theme(colors.yellow.700);
+}
+
+.badge-success {
+    background-color: theme(colors.green.100);
+    color: theme(colors.green.700);
+}
+
+.badge-danger {
+    background-color: theme(colors.red.100);
+    color: theme(colors.red.700);
+}
+
+.badge-secondary {
+    background-color: theme(colors.gray.100);
+    color: theme(colors.gray.700);
+}
+
+.order-details {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid theme(colors.gray.100);
+}
+
+.order-detail-item {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.9rem;
+}
+
+.detail-label {
+    color: theme(colors.gray.600);
+}
+
+.detail-value {
+    font-weight: 600;
+    color: #1F2937;
+}
+
+.order-total {
+    color: theme(colors.primary.600);
+}
+
+.products-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.product-card {
+    border: 1px solid theme(colors.gray.200);
+    border-radius: 12px;
+    overflow: hidden;
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.product-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+}
+
+.product-image-wrapper {
+    position: relative;
+    width: 100%;
+    height: 180px;
+    overflow: hidden;
+    background-color: theme(colors.gray.100);
+}
+
+.product-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.product-badge {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    padding: 0.25rem 0.75rem;
+    border-radius: 9999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+}
+
+.auction-badge {
+    background-color: theme(colors.primary.500);
+    color: white;
+}
+
+.product-info {
+    padding: 1rem;
+}
+
+.product-name {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #1F2937;
+    margin-bottom: 0.75rem;
+}
+
+.product-details {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.product-detail-row {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.9rem;
+}
+
+.product-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    color: theme(colors.primary.500);
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: color 0.2s;
+}
+
+.product-link:hover {
+    color: theme(colors.primary.700);
+}
+
+/*#endregion*/
+
 /*#region Order Details*/
 .order-header-back-button {
     height: auto;


### PR DESCRIPTION
Elke page heeft nu data dat uit de database komt ipv dummydata. 

Kweker:
Dashboard stats (totaal producten, bestellingen, omzet)
Order stats (totaal, in afwachting, afgerond, geannuleerd)
Omzet grafiek met dag/maand toggle

Veilingmeester:
Dashboard stats (totaal veilingklokken, actieve veilingklokken, totaal producten, totaal bestellingen)
Producten pagina stats (totaal producten, actieve producten, inactieve producten)

Koper:
Orders pagina stats (totaal bestellingen, in afwachting, afgerond, geannuleerd)
Veilingen pagina stats (actieve veilingen, geplande veilingen, beschikbare producten, jouw aankopen)

en nog een aantal text fixes